### PR TITLE
speed 문제 해결, ptera flag 참조 이슈 해결

### DIFF
--- a/src/arcade.py
+++ b/src/arcade.py
@@ -500,8 +500,9 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                         pass
                     else:
                         #p1
+                        ptera_hit = False
+                        
                         if len(p1_m_list)!= 0:
-                            ptera_hit = False
                             if (p1_m.x>=p.rect.left)and(p1_m.x<=p.rect.right)and(p1_m.y>p.rect.top)and(p1_m.y<p.rect.bottom):
                                 ptera_hit = True
                                 p1_m_list.remove(p1_m)
@@ -625,7 +626,7 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                     if pygame.sprite.collide_mask(player1, k):
                         if pygame.mixer.get_init() is not None:
                             checkPoint_sound.play()
-                        gamespeed -= 1
+                        gamespeed_down()
                         new_ground.speed += 1
                         k.kill()
                     elif k.rect.right < 0:
@@ -676,7 +677,7 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                     if pygame.sprite.collide_mask(player2, k):
                         if pygame.mixer.get_init() is not None:
                             checkPoint_sound.play()
-                        gamespeed -= 1
+                        gamespeed_down()
                         new_ground.speed += 1
                         k.kill()
                     elif k.rect.right < 0:
@@ -962,6 +963,9 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                             if (stage == 1):
                                 pygame.time.wait(500)
                                 gameplay_multi(stage + 1, p1_life, p2_life, gamespeed)
+                            elif (stage == 2):
+                                pygame.time.wait(500)
+                                # gameplay_hard(stage + 1, life, gamespeed, playerDino.score)
 
                             elif (stage == 3):
                                 print("모든 스테이지 클리어")

--- a/src/game.py
+++ b/src/game.py
@@ -1210,7 +1210,7 @@ def gameplay_hard(cur_stage=1, cur_life=15, cur_speed=4, cur_score=0):
                     if pygame.sprite.collide_mask(playerDino, k):
                         if pygame.mixer.get_init() is not None:
                             checkPoint_sound.play()
-                        gamespeed -= 1
+                        gamespeed_down()
                         new_ground.speed += 1
                         k.kill()
                     elif k.rect.right < 0:


### PR DESCRIPTION
1) speed 같은 경우 최소값인 1을 내려가지 않게끔 추가되었던 gamespeed_down가 SLOWITEM 부분에선 적용이 안되고 있었어서 범위체크를 하지않고 무작정 스피드를 낮추기만 것을 #17 번 이슈의 원인으로 발견함.
아케이드 플레이, 멀티 플레이 두가지 모드에서 해당 문제 해결
2) 멀티 플레이 모드에서 깔끔한 코드 구현을 위해 ptera가 맞았을 때 상태를 점검해주는 Flag를 추가했었는데, 코드 위치 때문에 선언이 되지않았다는 #16 이슈 해결 
