### PR TITLE
멀티모드에서 공룡이 맞은 보스 총알을 없앨 때 게임이 꺼지는 이슈 해결

### DIFF
--- a/src/arcade.py
+++ b/src/arcade.py
@@ -755,6 +755,7 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
 
 
                     #
+                    pm_bullet_dissolve = False
                     if (len(pm_list)==0):
                         pass
                     else:
@@ -770,7 +771,8 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                                 p1_collision_time = pygame.time.get_ticks()
                                 if p1_life <= 0:
                                     player1.isDead = True
-                                pm_list.remove(pm)
+                                pm_bullet_dissolve = True
+                                
                             #p2
                             if (pm.x>=player2.rect.left)and(pm.x<=player2.rect.right)and(pm.y>player2.rect.top)and(pm.y<player2.rect.bottom):
                                 print("공격에 맞음.")
@@ -782,7 +784,9 @@ def gameplay_multi(cur_stage=1, p1_cur_life=15, p2_cur_life=15, cur_speed =4):
                                 p2_collision_time = pygame.time.get_ticks()
                                 if p2_life <= 0:
                                     player2.isDead = True
-
+                                pm_bullet_dissolve = True
+                            
+                            if pm_bullet_dissolve == True:    
                                 pm_list.remove(pm)
                 else:
                     if len(cacti) < 2:


### PR DESCRIPTION
**이슈**: 멀티모드에서 공룡이 두마리가 보스에게 같은 총알에 맞을 경우에만 발생되는 이슈였다. #15 
**원인**: 특정 총알이 한 플레이어에게 맞았을 때, 그 특정 총알이 리스트에서 두 번 삭제되어야 하도록 기존 코드가 구현이 되어있었다
**해결방법**: 해당 이슈는 총알을 둘 중 한명이라도 맞았을 때의 상태를 기록하는 Flag를 추가하여 같은 총알이 두 플레이어에게 맞았을 때의 상태를 각각 두번 확인하지만 그 상태를 기반으로 총알은 한번만 없어지도록 하여 해결.